### PR TITLE
Scatter chart component

### DIFF
--- a/lib/components/Area/index.tsx
+++ b/lib/components/Area/index.tsx
@@ -1,1 +1,5 @@
-export { Area, type AreaProps } from "recharts";
+import { Area, type AreaProps as RechartsAreaProps } from "recharts";
+
+type AreaProps = Omit<RechartsAreaProps, "ref">;
+
+export { Area, type AreaProps };

--- a/lib/components/AreaChart/index.tsx
+++ b/lib/components/AreaChart/index.tsx
@@ -13,7 +13,7 @@ export const AreaChart: React.FC<AreaChartProps> = ({
   ...rest
 }) => (
   <div
-    className={cx("h-80 w-full", className)}
+    className={cx(className, "h-80 w-full")}
     data-testid="area-chart-wrapper"
   >
     <RechartsResponsiveContainer width="100%" height="100%">

--- a/lib/components/ChartCell/constants.ts
+++ b/lib/components/ChartCell/constants.ts
@@ -1,0 +1,7 @@
+import { type ChartCellProps } from ".";
+
+export const scatterChartCellProps: ChartCellProps = {
+  width: "20px",
+  height: "20px",
+  style: { opacity: 1 },
+};

--- a/lib/components/ChartCell/index.tsx
+++ b/lib/components/ChartCell/index.tsx
@@ -1,0 +1,1 @@
+export { Cell as ChartCell, type CellProps as ChartCellProps } from "recharts";

--- a/lib/components/ChartTooltip/Content.tsx
+++ b/lib/components/ChartTooltip/Content.tsx
@@ -9,7 +9,7 @@ export const ChartTooltipContent: React.FC<ContentProps> = ({
 }) => {
   return (
     <div
-      className={cx(className, "bg-gray-900 px-3 py-2 rounded-md")}
+      className={cx("bg-gray-900 px-3 py-2 rounded-md", className)}
       {...rest}
     >
       {children}

--- a/lib/components/ChartTooltip/Content.tsx
+++ b/lib/components/ChartTooltip/Content.tsx
@@ -1,0 +1,18 @@
+import { cx } from "../common/utils";
+
+type ContentProps = React.HTMLProps<HTMLDivElement>;
+
+export const ChartTooltipContent: React.FC<ContentProps> = ({
+  children,
+  className,
+  ...rest
+}) => {
+  return (
+    <div
+      className={cx(className, "bg-gray-900 px-3 py-2 rounded-md")}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+};

--- a/lib/components/ChartTooltip/DefaultTooltip.tsx
+++ b/lib/components/ChartTooltip/DefaultTooltip.tsx
@@ -1,20 +1,21 @@
-import { TooltipProps } from "recharts";
+import { TooltipProps as RechartsTooltipProps } from "recharts";
 import { ChartTooltipValue } from "./Value";
 import { ChartTooltipTitle } from "./Title";
 import { ChartTooltipFooter } from "./Footer";
-import { Payload } from "recharts/types/component/DefaultTooltipContent";
+import { Payload as RechartsTooltipPayload } from "recharts/types/component/DefaultTooltipContent";
 
-type TypeFromArray<T> = T extends Array<infer K> ? K : never;
+export type TooltipFullPayload = RechartsTooltipPayload<any, any>;
+type TooltipProps = RechartsTooltipProps<any, any>;
+type Payload = TooltipFullPayload["payload"];
 
-type PayloadEntry = TypeFromArray<any[]>;
-type LabelWithFormatter = string | ((payload: PayloadEntry) => string);
+type LabelWithFormatter = string | ((payload: Payload) => string);
 
-interface DefaultTooltipProps extends TooltipProps<any, any> {
+type DefaultTooltipProps = TooltipProps & {
   label: LabelWithFormatter;
-  valueFormatter: (entry: PayloadEntry, payload: Payload<any, any>) => string;
-  footerFormatter?: (entry: PayloadEntry) => string;
+  valueFormatter: (payload: Payload, fullPayload: TooltipFullPayload) => string;
+  footerFormatter?: (payload: Payload) => string;
   active?: boolean;
-}
+};
 
 export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({
   label,
@@ -43,10 +44,7 @@ export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({
   );
 };
 
-function getLabelText(
-  label: LabelWithFormatter,
-  payload: PayloadEntry,
-): string {
+function getLabelText(label: LabelWithFormatter, payload: Payload): string {
   if (typeof label === "string") return label;
   return label(payload);
 }

--- a/lib/components/ChartTooltip/DefaultTooltip.tsx
+++ b/lib/components/ChartTooltip/DefaultTooltip.tsx
@@ -2,30 +2,51 @@ import { TooltipProps } from "recharts";
 import { ChartTooltipValue } from "./Value";
 import { ChartTooltipTitle } from "./Title";
 import { ChartTooltipFooter } from "./Footer";
+import { Payload } from "recharts/types/component/DefaultTooltipContent";
 
 type TypeFromArray<T> = T extends Array<infer K> ? K : never;
 
+type PayloadEntry = TypeFromArray<any[]>;
+type LabelWithFormatter = string | ((payload: PayloadEntry) => string);
+
 interface DefaultTooltipProps extends TooltipProps<any, any> {
-  label: string;
-  valueFormatter: (payload: TypeFromArray<any[]>) => string;
-  footerFormatter?: (payload: TypeFromArray<any[]>) => string;
+  label: LabelWithFormatter;
+  valueFormatter: (entry: PayloadEntry, payload: Payload<any, any>) => string;
+  footerFormatter?: (entry: PayloadEntry) => string;
   active?: boolean;
 }
 
-export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({ label, valueFormatter, footerFormatter, active, payload }) => {
+export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({
+  label,
+  valueFormatter,
+  footerFormatter,
+  active,
+  payload,
+}) => {
   const firstPayload = payload?.[0];
   if (!active || !firstPayload) return null;
 
+  const labelText = getLabelText(label, firstPayload.payload);
+
   return (
     <div className="bg-gray-900 px-3 py-2 rounded-md">
-      <ChartTooltipTitle>{label}</ChartTooltipTitle>
-      {payload
-        ?.map((p, index) => (
-          <div key={index}>
-            <ChartTooltipValue value={valueFormatter(p.payload)}/>
-            {footerFormatter && <ChartTooltipFooter subtitle={footerFormatter(p.payload)} />}
-          </div>
-        ))}
+      <ChartTooltipTitle>{labelText}</ChartTooltipTitle>
+      {payload?.map((p, index) => (
+        <div key={index}>
+          <ChartTooltipValue value={valueFormatter(p.payload, p)} />
+          {footerFormatter && (
+            <ChartTooltipFooter subtitle={footerFormatter(p.payload)} />
+          )}
+        </div>
+      ))}
     </div>
   );
 };
+
+function getLabelText(
+  label: LabelWithFormatter,
+  payload: PayloadEntry,
+): string {
+  if (typeof label === "string") return label;
+  return label(payload);
+}

--- a/lib/components/ChartTooltip/DefaultTooltip.tsx
+++ b/lib/components/ChartTooltip/DefaultTooltip.tsx
@@ -3,19 +3,18 @@ import { ChartTooltipValue } from "./Value";
 import { ChartTooltipTitle } from "./Title";
 import { ChartTooltipFooter } from "./Footer";
 import { Payload as RechartsTooltipPayload } from "recharts/types/component/DefaultTooltipContent";
+import { ChartTooltipContent } from "./Content.tsx";
 
 export type TooltipFullPayload = RechartsTooltipPayload<any, any>;
 type TooltipProps = RechartsTooltipProps<any, any>;
 type Payload = TooltipFullPayload["payload"];
 
-type LabelWithFormatter = string | ((payload: Payload) => string);
-
-type DefaultTooltipProps = TooltipProps & {
-  label: LabelWithFormatter;
-  valueFormatter: (payload: Payload, fullPayload: TooltipFullPayload) => string;
+interface DefaultTooltipProps extends TooltipProps {
+  label: string;
+  valueFormatter: (payload: Payload) => string;
   footerFormatter?: (payload: Payload) => string;
   active?: boolean;
-};
+}
 
 export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({
   label,
@@ -27,24 +26,17 @@ export const DefaultTooltip: React.FC<DefaultTooltipProps> = ({
   const firstPayload = payload?.[0];
   if (!active || !firstPayload) return null;
 
-  const labelText = getLabelText(label, firstPayload.payload);
-
   return (
-    <div className="bg-gray-900 px-3 py-2 rounded-md">
-      <ChartTooltipTitle>{labelText}</ChartTooltipTitle>
+    <ChartTooltipContent>
+      <ChartTooltipTitle>{label}</ChartTooltipTitle>
       {payload?.map((p, index) => (
         <div key={index}>
-          <ChartTooltipValue value={valueFormatter(p.payload, p)} />
+          <ChartTooltipValue>{valueFormatter(p.payload)}</ChartTooltipValue>
           {footerFormatter && (
             <ChartTooltipFooter subtitle={footerFormatter(p.payload)} />
           )}
         </div>
       ))}
-    </div>
+    </ChartTooltipContent>
   );
 };
-
-function getLabelText(label: LabelWithFormatter, payload: Payload): string {
-  if (typeof label === "string") return label;
-  return label(payload);
-}

--- a/lib/components/ChartTooltip/Title.tsx
+++ b/lib/components/ChartTooltip/Title.tsx
@@ -1,3 +1,13 @@
-export const ChartTooltipTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <p className="text-xs text-gray-400">{children}</p>
+import { cx } from "../common/utils.ts";
+
+type ChartTooltipTitleProps = React.HTMLProps<HTMLParagraphElement>;
+
+export const ChartTooltipTitle: React.FC<ChartTooltipTitleProps> = ({
+  children,
+  className,
+  ...rest
+}) => (
+  <p className={cx(className, "text-xs text-gray-400")} {...rest}>
+    {children}
+  </p>
 );

--- a/lib/components/ChartTooltip/Value.tsx
+++ b/lib/components/ChartTooltip/Value.tsx
@@ -1,3 +1,13 @@
-export const ChartTooltipValue: React.FC<{ value: string }> = ({ value }) => (
-  <p className="text-sm text-white">{value}</p>
+import { cx } from "../common/utils.ts";
+
+type ChartTooltipValueProps = React.HTMLProps<HTMLParagraphElement>;
+
+export const ChartTooltipValue: React.FC<ChartTooltipValueProps> = ({
+  children,
+  className,
+  ...rest
+}) => (
+  <p className={cx(className, "text-sm text-white gap-1 flex")} {...rest}>
+    {children}
+  </p>
 );

--- a/lib/components/ChartTooltip/constants.ts
+++ b/lib/components/ChartTooltip/constants.ts
@@ -1,0 +1,16 @@
+import { TooltipProps } from "recharts";
+
+const cursor = { fill: "#d1d5db", opacity: "0.15" };
+
+export const defaultTooltipProps: TooltipProps<any, any> = {
+  cursor,
+  position: { y: 0 },
+  isAnimationActive: false,
+  wrapperStyle: { outline: "none" },
+};
+
+export const scatterChartTooltipProps: TooltipProps<any, any> = {
+  cursor,
+  isAnimationActive: false, // todo: verify, in app this is true by default
+  wrapperStyle: { outline: "none" },
+};

--- a/lib/components/ChartTooltip/constants.ts
+++ b/lib/components/ChartTooltip/constants.ts
@@ -11,6 +11,6 @@ export const defaultTooltipProps: TooltipProps<any, any> = {
 
 export const scatterChartTooltipProps: TooltipProps<any, any> = {
   cursor,
-  isAnimationActive: false, // todo: verify, in app this is true by default
+  isAnimationActive: false,
   wrapperStyle: { outline: "none" },
 };

--- a/lib/components/ChartTooltip/index.tsx
+++ b/lib/components/ChartTooltip/index.tsx
@@ -1,27 +1,17 @@
-
-import { Tooltip as RechartsTooltip } from "recharts";
+import {
+  Tooltip as ChartTooltip,
+  TooltipProps as ChartTooltipProps,
+} from "recharts";
 import { ChartTooltipValue } from "./Value";
 import { ChartTooltipTitle } from "./Title";
 import { ChartTooltipFooter } from "./Footer";
 import { DefaultTooltip } from "./DefaultTooltip";
 
-export interface TooltipProps {
-  label?: string;
-  active?: boolean;
-  payload?: any[];
-  valueFormatter: (payload: any) => string;
-  footerFormatter?: (payload: any) => string;
-}
-
-class ChartTooltip extends RechartsTooltip<any, any> {
-  static defaultProps = {
-    ...RechartsTooltip.defaultProps,
-    cursor: { fill: "#d1d5db", opacity: "0.15" } as any,
-    position: { y: 0 },
-    isAnimationActive: false,
-    wrapperStyle: { outline: "none" },
-  };
-}
-
-
-export { ChartTooltip, ChartTooltipTitle, ChartTooltipValue, ChartTooltipFooter, DefaultTooltip };
+export {
+  ChartTooltip,
+  ChartTooltipTitle,
+  ChartTooltipValue,
+  ChartTooltipFooter,
+  DefaultTooltip,
+  type ChartTooltipProps,
+};

--- a/lib/components/ChartTooltip/index.tsx
+++ b/lib/components/ChartTooltip/index.tsx
@@ -6,6 +6,7 @@ import { ChartTooltipValue } from "./Value";
 import { ChartTooltipTitle } from "./Title";
 import { ChartTooltipFooter } from "./Footer";
 import { DefaultTooltip } from "./DefaultTooltip";
+import { ChartTooltipContent } from "./Content";
 
 export {
   ChartTooltip,
@@ -13,5 +14,6 @@ export {
   ChartTooltipValue,
   ChartTooltipFooter,
   DefaultTooltip,
+  ChartTooltipContent,
   type ChartTooltipProps,
 };

--- a/lib/components/Grid/constants.ts
+++ b/lib/components/Grid/constants.ts
@@ -6,3 +6,9 @@ export const defaultGridProps: GridProps = {
   strokeDasharray: "3",
   className: "stroke-1",
 };
+
+export const scatterGridProps = {
+  vertical: false,
+  strokeDasharray: "3 3",
+  className: "stroke-gray-300",
+};

--- a/lib/components/ReferenceLine/constants.ts
+++ b/lib/components/ReferenceLine/constants.ts
@@ -4,3 +4,13 @@ export const defaultReferenceLineProps: ReferenceLineProps = {
   stroke: "inherit",
   className: "stroke-gray-300",
 };
+
+export const scatterReferenceLineXProps: ReferenceLineProps = {
+  ...defaultReferenceLineProps,
+  x: 50,
+};
+
+export const scatterReferenceLineYProps: ReferenceLineProps = {
+  ...defaultReferenceLineProps,
+  y: 50,
+};

--- a/lib/components/Scatter/ScatterShapeCircle.tsx
+++ b/lib/components/Scatter/ScatterShapeCircle.tsx
@@ -1,0 +1,17 @@
+export const ScatterShapeCircle = (props: unknown): React.ReactElement => {
+  const svgProps = props as React.SVGProps<SVGCircleElement>;
+  return (
+    <circle
+      r="10"
+      cx={svgProps.cx}
+      cy={svgProps.cy}
+      fill={svgProps.fill}
+      height={svgProps.height}
+      name={svgProps.name}
+      style={svgProps.style}
+      width={svgProps.width}
+      x={svgProps.x}
+      y={svgProps.y}
+    />
+  );
+};

--- a/lib/components/Scatter/constants.ts
+++ b/lib/components/Scatter/constants.ts
@@ -1,5 +1,6 @@
 import { type ScatterProps } from ".";
+import { ScatterShapeCircle } from "./ScatterShapeCircle.tsx";
 
 export const defaultScatterProps: ScatterProps = {
-  shape: <circle r="10" />,
+  shape: ScatterShapeCircle,
 };

--- a/lib/components/Scatter/constants.tsx
+++ b/lib/components/Scatter/constants.tsx
@@ -1,0 +1,5 @@
+import { type ScatterProps } from ".";
+
+export const defaultScatterProps: ScatterProps = {
+  shape: <circle r="10" />,
+};

--- a/lib/components/Scatter/index.ts
+++ b/lib/components/Scatter/index.ts
@@ -1,0 +1,5 @@
+import { Scatter, ScatterProps as RechartsScatterProps } from "recharts";
+
+type ScatterProps = Omit<RechartsScatterProps, "ref">;
+
+export { Scatter, type ScatterProps };

--- a/lib/components/ScatterChart/index.tsx
+++ b/lib/components/ScatterChart/index.tsx
@@ -1,0 +1,26 @@
+import {
+  ScatterChart as RechartsScatterChart,
+  ResponsiveContainer as RechartsResponsiveContainer,
+} from "recharts";
+
+import { cx } from "../common/utils";
+import React from "react";
+
+type ScatterChartProps = React.ComponentProps<typeof RechartsScatterChart>;
+
+export type { ScatterChartProps };
+
+export const ScatterChart: React.FC<ScatterChartProps> = ({
+  className,
+  children,
+  ...rest
+}) => (
+  <div
+    data-testid="scatter-chart-wrapper"
+    className={cx(className, "w-full h-80")}
+  >
+    <RechartsResponsiveContainer className="w-full h-full">
+      <RechartsScatterChart {...rest}>{children}</RechartsScatterChart>
+    </RechartsResponsiveContainer>
+  </div>
+);

--- a/lib/components/ScatterChartTick/index.tsx
+++ b/lib/components/ScatterChartTick/index.tsx
@@ -8,7 +8,7 @@ type ScatterChartTickProps = {
   unit?: string;
   dx?: number;
   dy?: number;
-};
+} & React.SVGProps<SVGTextElement>;
 
 export const ScatterChartTick: React.FC<ScatterChartTickProps> = ({
   x,
@@ -17,11 +17,19 @@ export const ScatterChartTick: React.FC<ScatterChartTickProps> = ({
   dy = 0,
   unit,
   ...rest
-}: ScatterChartTickProps) => {
-  return (
-    <TickText x={x + dx} y={y + dy} {...rest}>
-      {rest.payload.value}
-      {unit}
-    </TickText>
-  );
-};
+}: ScatterChartTickProps) => (
+  <TickText
+    x={x + dx}
+    y={y + dy}
+    fill={rest.fill}
+    height={rest.height}
+    name={rest.name}
+    orientation={rest.orientation}
+    stroke={rest.stroke}
+    textAnchor={rest.textAnchor}
+    width={rest.width}
+  >
+    {rest.payload.value}
+    {unit}
+  </TickText>
+);

--- a/lib/components/ScatterChartTick/index.tsx
+++ b/lib/components/ScatterChartTick/index.tsx
@@ -1,0 +1,27 @@
+import { TickText } from "../TickText";
+import { Payload } from "recharts/types/component/DefaultTooltipContent";
+
+type ScatterChartTickProps = {
+  x: number;
+  y: number;
+  payload: Payload<number, string>;
+  unit?: string;
+  dx?: number;
+  dy?: number;
+};
+
+export const ScatterChartTick: React.FC<ScatterChartTickProps> = ({
+  x,
+  y,
+  dx = 0,
+  dy = 0,
+  unit,
+  ...rest
+}: ScatterChartTickProps) => {
+  return (
+    <TickText x={x + dx} y={y + dy} {...rest}>
+      {rest.payload.value}
+      {unit}
+    </TickText>
+  );
+};

--- a/lib/components/TickText/index.tsx
+++ b/lib/components/TickText/index.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import { cx } from "../common/utils.ts";
 
 export type TickTextProps = React.SVGProps<SVGTextElement>;
 
-export const TickText: React.FC<TickTextProps> = ({ children, ...props }) => {
-  return (
-    <text {...props} className="text-xs text-gray-800">
-      {children}
-    </text>
-  );
-};
+export const TickText: React.FC<TickTextProps> = ({
+  children,
+  className,
+  ...rest
+}) => (
+  <text {...rest} className={cx("text-xs text-gray-800", className)}>
+    {children}
+  </text>
+);

--- a/lib/components/TickText/index.tsx
+++ b/lib/components/TickText/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export type TickTextProps = React.SVGProps<SVGTextElement>;
+
+export const TickText: React.FC<TickTextProps> = ({ children, ...props }) => {
+  return (
+    <text {...props} className="text-xs text-gray-800">
+      {children}
+    </text>
+  );
+};

--- a/lib/components/XAxis/constants.ts
+++ b/lib/components/XAxis/constants.ts
@@ -1,9 +1,18 @@
 import { XAxisProps } from "recharts";
 
+export const PERCENTAGE_TICKS = [0, 25, 50, 75, 100];
+
 export const defaultXAxisProps: XAxisProps = {
   interval: "preserveStartEnd",
   className: "text-xs fill-gray-600",
   minTickGap: 5,
   fill: "",
   stroke: "",
+};
+
+export const scatterXAxisProps: XAxisProps = {
+  axisLine: { className: "stroke-gray-300" },
+  tickLine: false,
+  type: "number",
+  ticks: PERCENTAGE_TICKS,
 };

--- a/lib/components/XAxis/index.tsx
+++ b/lib/components/XAxis/index.tsx
@@ -1,6 +1,5 @@
-import { XAxisProps } from "recharts";
+import { XAxis, XAxisProps as RechartsXAxisProps } from "recharts";
 
-export { XAxis } from "recharts";
+type XAxisProps = Omit<RechartsXAxisProps, "ref">;
 
-export type { XAxisProps };
-
+export { XAxis, type XAxisProps };

--- a/lib/components/YAxis/constants.ts
+++ b/lib/components/YAxis/constants.ts
@@ -1,4 +1,5 @@
 import { type YAxisProps } from "recharts";
+import { PERCENTAGE_TICKS } from "../XAxis/constants.ts";
 
 export const defaultYAxisProps: YAxisProps = {
   axisLine: false,
@@ -6,4 +7,11 @@ export const defaultYAxisProps: YAxisProps = {
   className: "text-xs fill-gray-600",
   fill: "",
   stroke: "",
+};
+
+export const scatterYAxisProps: YAxisProps = {
+  axisLine: false,
+  tickLine: false,
+  type: "number",
+  ticks: PERCENTAGE_TICKS,
 };

--- a/lib/components/YAxis/index.tsx
+++ b/lib/components/YAxis/index.tsx
@@ -1,6 +1,5 @@
-import { YAxisProps } from "recharts";
+import { YAxis, type YAxisProps as RechartsYAxisProps } from "recharts";
 
-export { YAxis } from "recharts";
+type YAxisProps = Omit<RechartsYAxisProps, "ref">;
 
-export type { YAxisProps };
-
+export { YAxis, type YAxisProps };

--- a/lib/components/common/colors.tsx
+++ b/lib/components/common/colors.tsx
@@ -2,3 +2,18 @@ export const colors: { [key: string]: string } = {
   backgroundColor: "#f7f7f7",
 };
 
+export const visualizationColors = [
+  "rgba(224, 180, 241, 1)",
+  "rgba(237, 181, 180, 1)",
+  "rgba(181, 240, 220, 1)",
+  "#FDF3D9",
+  "#DEE1FC",
+  "#D63A35",
+  "#666CEF",
+  "#9DBF9E",
+  "#F4D35E",
+  "#EBEBD3",
+  "#F9B5AC",
+  "#C1666B",
+  "#48A9A6",
+];

--- a/lib/components/common/utils.ts
+++ b/lib/components/common/utils.ts
@@ -1,5 +1,6 @@
-import { ValueFormatter } from "../../configurationTypes";
 import { twMerge } from "tailwind-merge";
+import { ValueFormatter } from "../../configurationTypes";
+import { visualizationColors } from "./colors.tsx";
 
 export const getYAxisDomain = (
   autoMinValue: boolean,
@@ -67,4 +68,23 @@ export function addLoadedIdToElement() {
   if (elements.length > 0 && elements[0]) {
     elements[0].id = "loaded";
   }
+}
+
+/**
+ * Returns a June visualization color deterministically based on the input.
+ * @param input - string or number
+ */
+export function imagineColor(input: number | string): string {
+  const index = typeof input === "number" ? input : getUniqueColorIndex(input);
+  return visualizationColors[index % visualizationColors.length];
+}
+
+function getUniqueColorIndex(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Ensures the hash is a 32-bit integer
+  }
+  return Math.abs(hash);
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,13 +5,22 @@ export type { BarChartProps } from "./components/BarChart";
 export { BarItem } from "./components/BarChart/BarItem";
 export type { BarItemProps } from "./components/BarChart/BarItem";
 export { XAxis } from "./components/XAxis";
-export { defaultXAxisProps } from "./components/XAxis/constants";
+export {
+  defaultXAxisProps,
+  scatterXAxisProps,
+} from "./components/XAxis/constants";
 export type { XAxisProps } from "./components/XAxis";
 export { YAxis } from "./components/YAxis";
-export { defaultYAxisProps } from "./components/YAxis/constants";
+export {
+  defaultYAxisProps,
+  scatterYAxisProps,
+} from "./components/YAxis/constants";
 export type { YAxisProps } from "./components/YAxis";
 export { Grid, type GridProps } from "./components/Grid";
-export { defaultGridProps } from "./components/Grid/constants";
+export {
+  defaultGridProps,
+  scatterGridProps,
+} from "./components/Grid/constants";
 export {
   ChartTooltip,
   DefaultTooltip,
@@ -61,9 +70,11 @@ export {
 export { TickText, type TickTextProps } from "./components/TickText";
 export { imagineColor } from "./components/common/utils";
 export { ChartCell, type ChartCellProps } from "./components/ChartCell";
+export { scatterChartCellProps } from "./components/ChartCell/constants";
 export {
   ScatterChart,
   type ScatterChartProps,
 } from "./components/ScatterChart";
 export { Scatter, type ScatterProps } from "./components/Scatter";
 export { defaultScatterProps } from "./components/Scatter/constants";
+export { ScatterChartTick } from "./components/ScatterChartTick";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -18,7 +18,12 @@ export {
   ChartTooltipTitle,
   ChartTooltipValue,
   ChartTooltipFooter,
+  type ChartTooltipProps,
 } from "./components/ChartTooltip";
+export {
+  defaultTooltipProps,
+  scatterChartTooltipProps,
+} from "./components/ChartTooltip/constants";
 export { EmptyState } from "./components/EmptyState";
 export type { EmptyStateProps } from "./components/EmptyState";
 export {
@@ -40,16 +45,25 @@ export {
   ReferenceLine,
   type ReferenceLineProps,
 } from "./components/ReferenceLine";
-export { defaultReferenceLineProps } from "./components/ReferenceLine/constants.ts";
-
+export {
+  defaultReferenceLineProps,
+  scatterReferenceLineYProps,
+  scatterReferenceLineXProps,
+} from "./components/ReferenceLine/constants.ts";
 export { Dot } from "./components/Dot";
 export { defaultDotProps } from "./components/Dot/constants";
-
 export { Legend, type LegendProps } from "./components/Legend";
 export { ChartLabel, type ChartLabelProps } from "./components/ChartLabel";
 export {
   ChartLabelText,
   type ChartLabelTextProps,
 } from "./components/ChartLabel/ChartLabelText.tsx";
-
+export { TickText, type TickTextProps } from "./components/TickText";
 export { imagineColor } from "./components/common/utils";
+export { ChartCell, type ChartCellProps } from "./components/ChartCell";
+export {
+  ScatterChart,
+  type ScatterChartProps,
+} from "./components/ScatterChart";
+export { Scatter, type ScatterProps } from "./components/Scatter";
+export { defaultScatterProps } from "./components/Scatter/constants";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -27,6 +27,7 @@ export {
   ChartTooltipTitle,
   ChartTooltipValue,
   ChartTooltipFooter,
+  ChartTooltipContent,
   type ChartTooltipProps,
 } from "./components/ChartTooltip";
 export {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -51,3 +51,5 @@ export {
   ChartLabelText,
   type ChartLabelTextProps,
 } from "./components/ChartLabel/ChartLabelText.tsx";
+
+export { imagineColor } from "./components/common/utils";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.12",
       "dependencies": {
         "@headlessui/react": "^1.7.19",
-        "recharts": "^2.12.5",
+        "recharts": "^2.12.7",
         "tailwind-merge": "^2.3.0"
       },
       "devDependencies": {
@@ -13462,9 +13462,9 @@
       "dev": true
     },
     "node_modules/recharts": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.5.tgz",
-      "integrity": "sha512-Cy+BkqrFIYTHJCyKHJEPvbHE2kVQEP6PKbOHJ8ztRGTAhvHuUnCwDaKVb13OwRFZ0QNUk1QvGTDdgWSMbuMtKw==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.19",
-    "recharts": "^2.12.5",
+    "recharts": "^2.12.7",
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import {
   BarItem,
   ChartTooltip,
   defaultGridProps,
+  defaultTooltipProps,
   defaultXAxisProps,
   defaultYAxisProps,
   EmptyState,
@@ -13,7 +14,6 @@ import {
 import { DefaultTooltip } from "../lib/components/ChartTooltip";
 
 function App() {
-
   return (
     <>
       <div>Empty Bar Chart</div>
@@ -35,9 +35,17 @@ function App() {
           categories={["Sales"]}
           index={"month"}
         >
-          <ChartTooltip 
-            content={({ active, payload, label }) => <DefaultTooltip label={label} active={active} payload={payload} valueFormatter={(p)=> `${p.Sales} Sales`} />}
-            />
+          <ChartTooltip
+            {...defaultTooltipProps}
+            content={({ active, payload, label }) => (
+              <DefaultTooltip
+                label={label}
+                active={active}
+                payload={payload}
+                valueFormatter={(p) => `${p.Sales} Sales`}
+              />
+            )}
+          />
           {/* This is ugly but it's a workaround for now waiting  https://github.com/recharts/recharts/issues/3615#issuecomment-1651094565 to be fixed */}
           <Grid {...defaultGridProps} />
           <BarItem dataKey="Sales" />
@@ -46,7 +54,7 @@ function App() {
         </BarChart>
       </div>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/stories/AreaChart.stories.tsx
+++ b/src/stories/AreaChart.stories.tsx
@@ -8,6 +8,7 @@ import {
   defaultGridProps,
   defaultReferenceLineProps,
   DefaultTooltip,
+  defaultTooltipProps,
   defaultXAxisProps,
   defaultYAxisProps,
   Dot,
@@ -55,7 +56,8 @@ export const Default: Story = {
       <YAxis {...defaultYAxisProps} dataKey="y" />
       <XAxis {...defaultXAxisProps} dataKey="x" />
       <ChartTooltip
-        content={({ active, payload, label }) => (
+          {...defaultTooltipProps}
+          content={({ active, payload, label }) => (
           <DefaultTooltip
             label={label}
             active={active}

--- a/src/stories/BarChart.stories.tsx
+++ b/src/stories/BarChart.stories.tsx
@@ -4,6 +4,7 @@ import {
   ChartTooltip,
   defaultGridProps,
   DefaultTooltip,
+  defaultTooltipProps,
   defaultXAxisProps,
   defaultYAxisProps,
   XAxis,
@@ -23,11 +24,10 @@ const data = [
   },
 ];
 
-
 const meta: Meta<typeof BarChart> = {
   title: "Visualizations/Chart/BarChart",
   component: BarChart,
-  args: { categories: ["Sales"], index: "month", data, className: "h-72"},
+  args: { categories: ["Sales"], index: "month", data, className: "h-72" },
   parameters: {
     sourceLink:
       "https://github.com/juneHQ/june-charts/tree/main/lib/components/BarChart/index.tsx",
@@ -39,13 +39,21 @@ export default meta;
 type Story = StoryObj<typeof BarChart>;
 
 export const Default: Story = {
-  args: { categories: ["Sales"], index: "month", data, className: "h-72"},
+  args: { categories: ["Sales"], index: "month", data, className: "h-72" },
   render: (args) => (
     <>
-      <BarChart {...args} >
-        <Grid  {...defaultGridProps}  />
-        <ChartTooltip 
-            content={({ active, payload, label }) => <DefaultTooltip label={label} active={active} payload={payload} valueFormatter={(p)=> `${p.Sales} Sales`} />}
+      <BarChart {...args}>
+        <Grid {...defaultGridProps} />
+        <ChartTooltip
+          {...defaultTooltipProps}
+          content={({ active, payload, label }) => (
+            <DefaultTooltip
+              label={label}
+              active={active}
+              payload={payload}
+              valueFormatter={(p) => `${p.Sales} Sales`}
+            />
+          )}
         />
         <BarItem dataKey="Sales" />
         <YAxis {...defaultYAxisProps} />
@@ -56,7 +64,6 @@ export const Default: Story = {
 };
 
 export const PowerUsersL7D: Story = {
-
   args: {
     categories: ["groupsPercentage"],
     index: "name",
@@ -108,12 +115,23 @@ export const PowerUsersL7D: Story = {
 
   render: (args) => (
     <BarChart {...args}>
-      <Grid  {...defaultGridProps}  />
-      <ChartTooltip 
-          content={({ active, payload, label }) => <DefaultTooltip label={label} active={active} payload={payload} valueFormatter={(payload: any) => `${payload.groupsPercentage}%`} footerFormatter={(payload: any) => `Click to see all ${payload.groupsCount} companies`} />}
+      <Grid {...defaultGridProps} />
+      <ChartTooltip
+        {...defaultTooltipProps}
+        content={({ active, payload, label }) => (
+          <DefaultTooltip
+            label={label}
+            active={active}
+            payload={payload}
+            valueFormatter={(payload: any) => `${payload.groupsPercentage}%`}
+            footerFormatter={(payload: any) =>
+              `Click to see all ${payload.groupsCount} companies`
+            }
+          />
+        )}
       />
       <BarItem dataKey="groupsPercentage" />
-      <YAxis {...defaultYAxisProps} tickFormatter={(p)=> `${p}%`} />
+      <YAxis {...defaultYAxisProps} tickFormatter={(p) => `${p}%`} />
       <XAxis {...defaultXAxisProps} dataKey="name" />
     </BarChart>
   ),

--- a/src/stories/LineChart.stories.tsx
+++ b/src/stories/LineChart.stories.tsx
@@ -9,6 +9,7 @@ import {
   defaultYAxisProps,
   XAxis,
   YAxis,
+  defaultTooltipProps,
 } from "../../lib/main";
 import { Grid } from "../../lib/components/Grid";
 
@@ -57,6 +58,7 @@ export const Default: Story = {
       <LineChart {...args}>
         <Grid {...defaultGridProps} />
         <ChartTooltip
+          {...defaultTooltipProps}
           content={({ active, payload, label }) => (
             <DefaultTooltip
               label={label}

--- a/src/stories/ScatterChart.stories.tsx
+++ b/src/stories/ScatterChart.stories.tsx
@@ -10,17 +10,17 @@ import {
   scatterChartTooltipProps,
   scatterReferenceLineXProps,
   scatterReferenceLineYProps,
-  TickText,
   XAxis,
   YAxis,
+  Grid,
+  ScatterChartTick,
+  scatterGridProps,
+  scatterYAxisProps,
+  scatterXAxisProps,
+  scatterChartCellProps,
 } from "../../lib/main";
-import { Grid } from "../../lib/components/Grid";
 
 import type { Meta, StoryObj } from "@storybook/react";
-import { scatterGridProps } from "../../lib/components/Grid/constants.ts";
-import { scatterYAxisProps } from "../../lib/components/YAxis/constants.ts";
-import { scatterXAxisProps } from "../../lib/components/XAxis/constants.ts";
-import { scatterChartCellProps } from "../../lib/components/ChartCell/constants.ts";
 
 const meta: Meta<typeof ScatterChart> = {
   title: "Visualizations/Chart/ScatterChart",
@@ -98,18 +98,9 @@ export const Default: Story = {
           name="Popularity"
           unit="%"
           dataKey="popularity"
-          tick={({
-            x,
-            y,
-            ...props
-          }: {
-            x: number;
-            y: number;
-            payload: { value: number };
-          }) => (
-            <TickText x={x - 5} y={y + 5} {...props}>
-              {props.payload.value}%
-            </TickText>
+          type="number"
+          tick={(props) => (
+            <ScatterChartTick {...props} dx={-5} dy={5} unit="%" />
           )}
         />
         <XAxis
@@ -117,17 +108,8 @@ export const Default: Story = {
           name="Frequency"
           dataKey="frequency"
           unit="%"
-          tick={({
-            y,
-            ...props
-          }: {
-            y: number;
-            payload: { value: number };
-          }) => (
-            <TickText y={y + 10} {...props}>
-              {props.payload.value}%
-            </TickText>
-          )}
+          type="number"
+          tick={(props) => <ScatterChartTick {...props} dy={10} unit="%" />}
         />
       </ScatterChart>
     );

--- a/src/stories/ScatterChart.stories.tsx
+++ b/src/stories/ScatterChart.stories.tsx
@@ -2,7 +2,6 @@ import {
   ChartCell,
   ChartTooltip,
   defaultScatterProps,
-  DefaultTooltip,
   imagineColor,
   ReferenceLine,
   Scatter,
@@ -18,6 +17,9 @@ import {
   scatterYAxisProps,
   scatterXAxisProps,
   scatterChartCellProps,
+  ChartTooltipContent,
+  ChartTooltipTitle,
+  ChartTooltipValue,
 } from "../../lib/main";
 
 import type { Meta, StoryObj } from "@storybook/react";
@@ -34,12 +36,6 @@ const meta: Meta<typeof ScatterChart> = {
 export default meta;
 
 type Story = StoryObj<typeof ScatterChart>;
-
-type ScatterData = {
-  name: string;
-  frequency: number;
-  popularity: number;
-};
 
 const data = [
   {
@@ -77,16 +73,31 @@ export const Default: Story = {
         <Grid {...scatterGridProps} />
         <ChartTooltip
           {...scatterChartTooltipProps}
-          content={({ active, payload }) => (
-            <DefaultTooltip
-              label={(payload: ScatterData) => payload.name}
-              active={active}
-              payload={payload}
-              valueFormatter={(_, fullPayload) => {
-                return `${fullPayload.name}: ${fullPayload.value}${fullPayload.unit}`;
-              }}
-            />
-          )}
+          content={(props) => {
+            const { payload } = props;
+            const firstPayload = payload?.[0];
+
+            if (!firstPayload) {
+              console.error("No payload found in ScatterChart tooltip");
+              return;
+            }
+            return (
+              <ChartTooltipContent>
+                <ChartTooltipTitle className="text-white font-bold">
+                  {firstPayload.payload.name}
+                </ChartTooltipTitle>
+                {payload?.map((p) => (
+                  <ChartTooltipValue key={p.dataKey}>
+                    <span className="text-xs text-gray-400">{p.name}:</span>
+                    <span className="text-xs text-bold">
+                      {p.value}
+                      {p.unit}
+                    </span>
+                  </ChartTooltipValue>
+                ))}
+              </ChartTooltipContent>
+            );
+          }}
         />
         <ReferenceLine {...scatterReferenceLineYProps} />
         <ReferenceLine {...scatterReferenceLineXProps} />

--- a/src/stories/ScatterChart.stories.tsx
+++ b/src/stories/ScatterChart.stories.tsx
@@ -35,6 +35,12 @@ export default meta;
 
 type Story = StoryObj<typeof ScatterChart>;
 
+type ScatterData = {
+  name: string;
+  frequency: number;
+  popularity: number;
+};
+
 const data = [
   {
     name: "Product A",
@@ -73,11 +79,11 @@ export const Default: Story = {
           {...scatterChartTooltipProps}
           content={({ active, payload }) => (
             <DefaultTooltip
-              label={(entry) => entry.name}
+              label={(payload: ScatterData) => payload.name}
               active={active}
               payload={payload}
-              valueFormatter={(_, p) => {
-                return `${p.name}: ${p.value}${p.unit}`;
+              valueFormatter={(_, fullPayload) => {
+                return `${fullPayload.name}: ${fullPayload.value}${fullPayload.unit}`;
               }}
             />
           )}

--- a/src/stories/ScatterChart.stories.tsx
+++ b/src/stories/ScatterChart.stories.tsx
@@ -1,0 +1,135 @@
+import {
+  ChartCell,
+  ChartTooltip,
+  defaultScatterProps,
+  DefaultTooltip,
+  imagineColor,
+  ReferenceLine,
+  Scatter,
+  ScatterChart,
+  scatterChartTooltipProps,
+  scatterReferenceLineXProps,
+  scatterReferenceLineYProps,
+  TickText,
+  XAxis,
+  YAxis,
+} from "../../lib/main";
+import { Grid } from "../../lib/components/Grid";
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { scatterGridProps } from "../../lib/components/Grid/constants.ts";
+import { scatterYAxisProps } from "../../lib/components/YAxis/constants.ts";
+import { scatterXAxisProps } from "../../lib/components/XAxis/constants.ts";
+import { scatterChartCellProps } from "../../lib/components/ChartCell/constants.ts";
+
+const meta: Meta<typeof ScatterChart> = {
+  title: "Visualizations/Chart/ScatterChart",
+  component: ScatterChart,
+  parameters: {
+    sourceLink:
+      "https://github.com/juneHQ/june-charts/tree/main/lib/components/ScatterChart/index.tsx",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ScatterChart>;
+
+const data = [
+  {
+    name: "Product A",
+    frequency: 50,
+    popularity: 90,
+  },
+  {
+    name: "Product B",
+    frequency: 35,
+    popularity: 20,
+  },
+  {
+    name: "Product C",
+    frequency: 42,
+    popularity: 53,
+  },
+  {
+    name: "Product D",
+    frequency: 82,
+    popularity: 11,
+  },
+  {
+    name: "Product E",
+    frequency: 11,
+    popularity: 60,
+  },
+];
+
+export const Default: Story = {
+  args: { data },
+  render: (args) => {
+    return (
+      <ScatterChart>
+        <Grid {...scatterGridProps} />
+        <ChartTooltip
+          {...scatterChartTooltipProps}
+          content={({ active, payload }) => (
+            <DefaultTooltip
+              label={(entry) => entry.name}
+              active={active}
+              payload={payload}
+              valueFormatter={(_, p) => {
+                return `${p.name}: ${p.value}${p.unit}`;
+              }}
+            />
+          )}
+        />
+        <ReferenceLine {...scatterReferenceLineYProps} />
+        <ReferenceLine {...scatterReferenceLineXProps} />
+        <Scatter {...defaultScatterProps} data={args.data}>
+          {data.map((_, index) => (
+            <ChartCell
+              {...scatterChartCellProps}
+              key={index}
+              fill={imagineColor(index)}
+            />
+          ))}
+        </Scatter>
+        <YAxis
+          {...scatterYAxisProps}
+          name="Popularity"
+          unit="%"
+          dataKey="popularity"
+          tick={({
+            x,
+            y,
+            ...props
+          }: {
+            x: number;
+            y: number;
+            payload: { value: number };
+          }) => (
+            <TickText x={x - 5} y={y + 5} {...props}>
+              {props.payload.value}%
+            </TickText>
+          )}
+        />
+        <XAxis
+          {...scatterXAxisProps}
+          name="Frequency"
+          dataKey="frequency"
+          unit="%"
+          tick={({
+            y,
+            ...props
+          }: {
+            y: number;
+            payload: { value: number };
+          }) => (
+            <TickText y={y + 10} {...props}>
+              {props.payload.value}%
+            </TickText>
+          )}
+        />
+      </ScatterChart>
+    );
+  },
+};

--- a/src/tests/common/utils.test.ts
+++ b/src/tests/common/utils.test.ts
@@ -1,9 +1,11 @@
+import { visualizationColors } from "../../../lib/components/common/colors";
 import {
   constructCategoryColors,
   cx,
   deepEqual,
   defaultValueFormatter,
   getYAxisDomain,
+  imagineColor,
 } from "../../../lib/components/common/utils";
 
 describe("utils", () => {
@@ -70,6 +72,30 @@ describe("utils", () => {
   describe("defaultValueFormatter", () => {
     it("should convert a number to a string", () => {
       expect(defaultValueFormatter(123)).toBe("123");
+    });
+  });
+
+  describe("imagineColor", () => {
+    it('should return a color from the "visualizationColors" array', () => {
+      const color = imagineColor(0);
+      expect(color).toBe(visualizationColors[0]);
+    });
+    it("should return different colors by number input", () => {
+      const first = imagineColor(0);
+      const second = imagineColor(1);
+      expect(first).not.toBe(second);
+    });
+
+    it("should return different colors by string input", () => {
+      const first = imagineColor("a");
+      const second = imagineColor("b");
+      expect(first).not.toBe(second);
+    });
+
+    it("should return the same output for the same string", () => {
+      const first = imagineColor("long-test-input-123");
+      const second = imagineColor("long-test-input-123");
+      expect(first).toBe(second);
     });
   });
 });

--- a/src/tests/components/DefaultTooltip.test.tsx
+++ b/src/tests/components/DefaultTooltip.test.tsx
@@ -46,44 +46,4 @@ describe("DefaultTooltip", () => {
     expect(screen.getByText("$100")).toBeInTheDocument();
     expect(screen.getByText("Sub: 100")).toBeInTheDocument();
   });
-
-  it("should format values using full payload", () => {
-    const payload = { popularity: 12, frequency: 13 };
-    const fullPayload = [
-      { name: "Popularity", value: 12, unit: "%", payload },
-      { name: "Frequency", value: 13, unit: "%", payload },
-    ];
-    render(
-      <DefaultTooltip
-        label="Test Label"
-        payload={fullPayload}
-        active={true}
-        valueFormatter={(_, fullPayload) => {
-          return `${fullPayload.name}: ${fullPayload.value}${fullPayload.unit}`;
-        }}
-      />,
-    );
-
-    expect(screen.getByText("Popularity: 12%")).toBeInTheDocument();
-    expect(screen.getByText("Frequency: 13%")).toBeInTheDocument();
-  });
-
-  it("should format label when label is a function", () => {
-    const payload = [
-      {
-        value: 123,
-        payload: { name: "test-entry-name" },
-      },
-    ];
-    render(
-      <DefaultTooltip
-        label={(p: { name: string }) => `${p.name}`}
-        payload={payload}
-        active={true}
-        valueFormatter={(p: { value: number }) => `${p.value}`}
-      />,
-    );
-
-    expect(screen.getByText("test-entry-name")).toBeInTheDocument();
-  });
 });

--- a/src/tests/components/DefaultTooltip.test.tsx
+++ b/src/tests/components/DefaultTooltip.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "../test-utils";
 import { DefaultTooltip } from "../../../lib/main";
 
@@ -32,7 +31,8 @@ describe("DefaultTooltip", () => {
   });
 
   it("should render subtitle when tooltipSubtitleFormatter is provided", () => {
-    const mockTooltipSubtitleFormatter = (payload: any) => `Sub: ${payload.value}`;
+    const mockTooltipSubtitleFormatter = (payload: any) =>
+      `Sub: ${payload.value}`;
     render(
       <DefaultTooltip
         label="Test Label"
@@ -45,5 +45,45 @@ describe("DefaultTooltip", () => {
     expect(screen.getByText("Test Label")).toBeInTheDocument();
     expect(screen.getByText("$100")).toBeInTheDocument();
     expect(screen.getByText("Sub: 100")).toBeInTheDocument();
+  });
+
+  it("should format values using full payload", () => {
+    const payload = { popularity: 12, frequency: 13 };
+    const fullPayload = [
+      { name: "Popularity", value: 12, unit: "%", payload },
+      { name: "Frequency", value: 13, unit: "%", payload },
+    ];
+    render(
+      <DefaultTooltip
+        label="Test Label"
+        payload={fullPayload}
+        active={true}
+        valueFormatter={(_, fullPayload) => {
+          return `${fullPayload.name}: ${fullPayload.value}${fullPayload.unit}`;
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Popularity: 12%")).toBeInTheDocument();
+    expect(screen.getByText("Frequency: 13%")).toBeInTheDocument();
+  });
+
+  it("should format label when label is a function", () => {
+    const payload = [
+      {
+        value: 123,
+        payload: { name: "test-entry-name" },
+      },
+    ];
+    render(
+      <DefaultTooltip
+        label={(p: { name: string }) => `${p.name}`}
+        payload={payload}
+        active={true}
+        valueFormatter={(p: { value: number }) => `${p.value}`}
+      />,
+    );
+
+    expect(screen.getByText("test-entry-name")).toBeInTheDocument();
   });
 });

--- a/src/tests/components/ScatterChart.test.tsx
+++ b/src/tests/components/ScatterChart.test.tsx
@@ -1,0 +1,17 @@
+import { ScatterChart } from "../../../lib/main";
+import { render, screen } from "../test-utils";
+
+describe("Component ScatterChart", () => {
+  it("should render without crashing", async () => {
+    render(<ScatterChart />);
+    expect(
+      await screen.findByTestId("scatter-chart-wrapper"),
+    ).toBeInTheDocument();
+  });
+
+  it("should pass className to the wrapper", async () => {
+    render(<ScatterChart className="test-class" />);
+    const element = await screen.findByTestId("scatter-chart-wrapper");
+    expect(element).toHaveClass("test-class");
+  });
+});

--- a/src/tests/components/ScatterChartTick.test.tsx
+++ b/src/tests/components/ScatterChartTick.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "../test-utils";
+import { ScatterChartTick } from "../../../lib/main.ts";
+
+describe("Component ScatterChartTick", () => {
+  it("should render without crashing", async () => {
+    render(
+      <svg>
+        <ScatterChartTick x={0} y={0} payload={{ value: 100 }} unit="%" />
+      </svg>,
+    );
+    expect(await screen.findByText("100%")).toBeInTheDocument();
+  });
+
+  it("should calculate the correct x and y position", async () => {
+    render(
+      <svg>
+        <ScatterChartTick
+          x={10}
+          dx={-5}
+          y={20}
+          dy={5}
+          payload={{ value: 100 }}
+        />
+      </svg>,
+    );
+    const element = await screen.findByText("100");
+    expect(element).toHaveAttribute("x", "5");
+    expect(element).toHaveAttribute("y", "25");
+  });
+});


### PR DESCRIPTION
## Scatter chart component 

WIP

- [x]  revert tooltip changes and create a composable tooltip
- [x] agree on what to do with disabled tooltip animations 
- [x] agree on where to put shared constants 

other thoughts

- maybe should re-arrange chart stuff to a separate components/chart dir and organize component exports inside it's index files-s

```
// folder tree:
- components/
-- main.ts
-- ReferenceLine/
----/ ReferenceLine.tsx
--- / index.ts
--- / constants.ts

// ReferenceLine/index.ts would look like:
  export * from './constants'
  export { ReferenceLine } from './ReferenceLine'

// main.ts:
export * from './chart/ReferenceLine'
export * from './chart/ChartTooltip'
```